### PR TITLE
Remove extension from apple_test()

### DIFF
--- a/cross-platform-scale-2015-demo/ios/BUCK
+++ b/cross-platform-scale-2015-demo/ios/BUCK
@@ -41,7 +41,6 @@ apple_package(
 
 apple_test(
   name = 'BuckDemoAppTest',
-  extension = 'xctest',
   test_host_app = ':BuckDemoApp',
   srcs = ['tests/BuckDemoAppTest.m'],
   info_plist = 'tests/Test.plist',


### PR DESCRIPTION
Fixes a parsing error when running `buck install -r demo_app_ios`