### PR TITLE
Remove project_config

### DIFF
--- a/cross-platform-scale-2015-demo/BUCK
+++ b/cross-platform-scale-2015-demo/BUCK
@@ -7,7 +7,3 @@
 java_library(
   name = 'dummy_java_for_buck_project',
 )
-
-project_config(
-  src_target = ':dummy_java_for_buck_project'
-)

--- a/cross-platform-scale-2015-demo/android/BUCK
+++ b/cross-platform-scale-2015-demo/android/BUCK
@@ -12,7 +12,3 @@ android_binary(
     '//android/java/com/facebook/buck/demo:lib',
   ],
 )
-
-project_config(
-  src_target = ':demo-app',
-)

--- a/cross-platform-scale-2015-demo/android/cxx/BUCK
+++ b/cross-platform-scale-2015-demo/android/cxx/BUCK
@@ -18,7 +18,3 @@ cxx_library(
     '//android/java/com/facebook/buck/demo:lib',
   ],
 )
-
-project_config(
-  src_target = ':jni'
-)

--- a/cross-platform-scale-2015-demo/android/java/com/facebook/buck/demo/BUCK
+++ b/cross-platform-scale-2015-demo/android/java/com/facebook/buck/demo/BUCK
@@ -15,7 +15,3 @@ android_library(
     '//android:demo-app',
   ],
 )
-
-project_config(
-  src_target = ':lib',
-)

--- a/cross-platform-scale-2015-demo/android/resources/BUCK
+++ b/cross-platform-scale-2015-demo/android/resources/BUCK
@@ -12,7 +12,3 @@ android_resource(
     '//android/java/com/facebook/buck/demo:lib',
   ],
 )
-
-project_config(
-  src_target = ':res'
-)

--- a/cross-platform-scale-2015-demo/common/BUCK
+++ b/cross-platform-scale-2015-demo/common/BUCK
@@ -12,7 +12,3 @@ cxx_library(
     'PUBLIC',
   ],
 )
-
-project_config(
-  src_target = ':hello'
-)


### PR DESCRIPTION
`project_config` was removed some time ago. Now it's causing parsing failures and these targets need to be removed.