### PR TITLE
Show how to use includes in .buckconfig

### DIFF
--- a/hello-buck-cxx/.buckconfig
+++ b/hello-buck-cxx/.buckconfig
@@ -1,7 +1,12 @@
-
 [cxx]
   cxxppflags="-D HELLOSTRING=\"Buck\""
 
-[cxx#other_platform]
-  cxxppflags="-D HELLOSTRING=\"Chuck\""
+<file:cxx-other-platform/cxx-other-platform.include>
+
+#
+# Include the following configuration file if it 
+# exists. If the file does not exist, do nothing.
+# (Note the `?` prefix.)
+#
+<?file:future-platform/future-platform.include>
 

--- a/hello-buck-cxx/cxx-other-platform/cxx-other-platform.include
+++ b/hello-buck-cxx/cxx-other-platform/cxx-other-platform.include
@@ -1,0 +1,3 @@
+[cxx#other_platform]
+  cxxppflags="-D HELLOSTRING=\"Chuck\""
+


### PR DESCRIPTION
- Configuration files can include other configuration files.
- Included files can be specified using relative paths (recommended) or absolute paths from file system root.
- The included files can comprise complete sections or just key/values from a single section. Recommend complete sections only as a best practice.
- The question-mark prefix enables developers to include a file if it exists, but ignore inclusion directive otherwise.
- Documentation at the following URL:
<https://buckbuild.com/files-and-dirs/buckconfig.html>